### PR TITLE
#fixed: a mistake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We want to make contributing as easy as transparent as possible whether it is :
  ```
  4. Add a reference to original repositrory.
  ```
-    git remote upstream https://github.com/ALOKARYAN51/E-Library-frontend.git
+    git remote add upstream https://github.com/ALOKARYAN51/E-Library-frontend.git
   ```
   5. See changes using
 ```


### PR DESCRIPTION
The git command for adding original repo reference was 'git remote upstream [link]', but the actual command is 'git remote add upstream [link]'